### PR TITLE
docs: Remove preview notice - S3 Vectors is now GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Amazon S3 Vectors Embed CLI is a standalone command-line tool that simplifies the process of working with vector embeddings in S3 Vectors. You can create vector embeddings for your data using Amazon Bedrock and store and query them in your S3 vector index using single commands. 
 
-**Amazon S3 Vectors Embed CLI is in preview release and is subject to change.**
-
 ## Supported Commands
 
 **s3vectors-embed put**: Embed text, file content, or S3 objects and store them as vectors in an S3 vector index.


### PR DESCRIPTION
*Issue #, if available:* Remove preview notice - S3 Vectors is now GA

*Description of changes:*
  S3 Vectors is now generally available. Removing the preview notice from README.
  
  Changes:
  - Removed line: "Amazon S3 Vectors Embed CLI is in preview release and is subject to change."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
